### PR TITLE
BEX token expiration end of the day + FIX bug

### DIFF
--- a/backend/apps/auth/tools.py
+++ b/backend/apps/auth/tools.py
@@ -113,7 +113,11 @@ def create_access_token(user: User,
 
     expire: int = settings.TOKEN_EXPIRE
     if x_teamlock_app == "browser_ext":
-        expire: int = settings.TOKEN_EXPIRE_BROWSER_EXT
+        now = datetime.utcnow()
+        end = datetime(now.year, now.month, now.day, settings.END_DAY)
+        if now > end:
+            end += timedelta(days=1)
+        expire: int = int((end - now).seconds)
 
     access_token_expires: timedelta = timedelta(seconds=expire)
     expire = datetime.utcnow() + access_token_expires
@@ -135,7 +139,7 @@ def create_access_token(user: User,
         tmp_user["otp"] = x_teamlock_key in user.remember_key
 
     # Store token into Redis
-    RedisTools.store(encoded_jwt, json.dumps(tmp_user), expire=expire)
+    RedisTools.store(encoded_jwt, json.dumps(tmp_user), expire=access_token_expires)
     return Login(
         access_token=encoded_jwt,
         expireAt=expire.isoformat()

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -37,7 +37,7 @@ class AppSettings(BaseSettings):
     DEBUG: bool = os.environ.get("DEBUG", False)
     DEV_MODE: bool = os.environ.get("DEV_MODE") == True
     TOKEN_EXPIRE: int = os.environ.get("TOKEN_EXPIRE", 7200) # Default: 2 hours
-    TOKEN_EXPIRE_BROWSER_EXT: int = os.environ.get("TOKEN_EXPIRE_BROWSER_EXT", 86400) # Default: 1 day
+    END_DAY: int = os.environ.get("END_DAY", 20) # the end of the day default : 20PM
     SECRET_KEY: str = os.environ["SECRET_KEY"]
     MAX_USERS: int = os.environ.get("MAX_USERS", 0)
     VERSION: float = float(os.environ["VERSION"])


### PR DESCRIPTION
### FIX :
`expire` was passed in RedisTools.store but it's a **datetime** object representing the moment when the token will expire, we have to pass the `access_token_expires` which is the **number of seconds before the expiration**.


### Feature : 
We compare the current date and the current date at 20pm. 
If the current date is later than the other one, we have to save the token until tomorrow's end.
Then, we are able to get the number of seconds between those two dates => it's the expiration