### PR TITLE
front for reseting browsers list of otp

### DIFF
--- a/frontend/src/components/Profile/MFA.vue
+++ b/frontend/src/components/Profile/MFA.vue
@@ -53,6 +53,20 @@
                             >
                                 {{ $t('label.disable_otp') }}
                             </v-btn>
+                            <v-tooltip bottom>
+                                <template v-slot:activator="{ on, attrs }">
+                                    <v-btn
+                                        color="primary"
+                                        v-bind="attrs"
+                                        @click="resetBrowsersList"
+                                        class="mb-5"
+                                        v-on="on"
+                                    >
+                                        {{ $t("label.reset_browsers_list_otp") }}
+                                    </v-btn>
+                                </template>
+                                <span>{{ $t("help.reset_browsers_list_otp") }}</span>
+                            </v-tooltip>
                         </template>
                         <v-card>
                             <v-card-title>
@@ -197,7 +211,19 @@ export default defineComponent({
                     this.otp_value = ""
                     this.loadingValidate2FA = false
                 })
-        }
+        },
+
+        resetBrowsersList(){
+            http.post("/pro/api/v1/user/totp/reset-list")
+                .then(() => {
+                    this.$toast.success(this.$t('success.browsers_list_otp_reset'))
+                })
+                .catch((err) => {
+                    if (err.response.status === 400) {
+                        this.$toast.error(this.$t("error.otp_not_enabled"))
+                    }
+                })
+        },
     }
 
 })

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -181,7 +181,8 @@
         "admin_configuration": "Administrator",
         "twilio_phone_number": "Twilio Phone Number",
         "twilio_account_sid": "Twilio Account SID",
-        "twilio_auth_token": "Twilio Auth Token"
+        "twilio_auth_token": "Twilio Auth Token",
+        "reset_browsers_list_otp": "Reset browsers list"
     },
     "tooltip": {
         "dblclick_copy": "Double click to copy",
@@ -291,7 +292,8 @@
         "trash_emptied": "Trash emptied",
         "trash_restored": "Trash restored",
         "key_restored": "Secret restored",
-        "secret_shared": "The secret is successfully shared"
+        "secret_shared": "The secret is successfully shared",
+        "browsers_list_otp_reset": "The browsers list has been reset"
     },
     "warning": {
         "user_recovery": "Contact your IT Administrator before using the recovery.",
@@ -343,7 +345,8 @@
         "invalid_recovery_key": "Invalid recovery key",
         "max_users_limit": "You have reach the max users you can add. Please upgrade your subscription to add more.",
         "could_not_validate_credentials": "Incorrect username or password",
-        "too_many_auth_failures": "Too many authentication failures. Account locked up for 10 minutes"
+        "too_many_auth_failures": "Too many authentication failures. Account locked up for 10 minutes",
+        "otp_not_enabled": "Your OTP is not enabled"
     },
     "help": {
         "add_to_filter": "Click to filter",
@@ -397,7 +400,8 @@
         "restore_key": "Restore key",
         "context_menu_workspace": "Right click for more options",
         "copied": "Copied",
-        "show_read_notifications": "Show read notifications"
+        "show_read_notifications": "Show read notifications",
+        "reset_browsers_list_otp" : "Reset browsers list in your OTP"
     },
     "folder": {
         "edit": "Edit folder",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -178,7 +178,8 @@
         "admin_configuration": "Administrateur",
         "twilio_phone_number": "Numéro de téléphone Twilio",
         "twilio_account_sid": "Twilio Account SID",
-        "twilio_auth_token": "Twilio Auth Token"
+        "twilio_auth_token": "Twilio Auth Token",
+        "reset_browsers_list_otp": "Réinitialiser la liste des navigateurs"
     },
     "tooltip": {
         "dblclick_copy": "Double cliquez pour copier",
@@ -286,7 +287,8 @@
         "trash_emptied": "Corbeille vidée",
         "trash_restored": "Corbeille restaurée",
         "key_restored": "Secret restauré",
-        "secret_shared": "Secret partagé"
+        "secret_shared": "Secret partagé",
+        "browsers_list_otp_reset": "La liste des navigateurs a bien été vidée"
     },
     "warning": {
         "user_recovery": "Contactez votre administrateur avant utiliser la récupération.",
@@ -339,7 +341,8 @@
         "invalid_recovery_key": "Clé de récupération invalide",
         "max_users_limit": "Vous avez atteints le nombre maximum d'utilisateurs",
         "could_not_validate_credentials": "Email ou mot de passe incorrect",
-        "too_many_auth_failures": "Trop d'erreur d'authentification. Votre compte est bloqué pendant 10 minutes"
+        "too_many_auth_failures": "Trop d'erreur d'authentification. Votre compte est bloqué pendant 10 minutes",
+        "otp_not_enabled": "Votre OTP n'est pas activé"
     },
     "help": {
         "add_to_filter": "Cliquez pour filtrer",
@@ -390,7 +393,8 @@
         "restore_trash": "Restaurer la corbeille",
         "restore_key": "Restaurer la clé",
         "context_menu_workspace": "Clic droit pour plus d'options",
-        "copied": "Copié"
+        "copied": "Copié",
+        "reset_browsers_list_otp" : "Réinitialiser la liste des navigateurs dans votre OTP"
     },
     "folder": {
         "edit": "Editer un dossier",


### PR DESCRIPTION
The user has the possibility to reset the list of browsers he added when he logged in through otp on Teamlock.

That feature is accessible in the **profile** section, tab concerning the **Two factor**, he has a **button** where He can just click to reset.
![image](https://user-images.githubusercontent.com/78411800/200544508-8a73625f-25ed-4213-9204-49a8f3fe616a.png)

After clicking if everything went well, he is notified :
![image](https://user-images.githubusercontent.com/78411800/200544703-63b55d8e-5d65-4e90-8dd4-8b3a3edbc367.png)

