### PR TITLE
generate password depending on folder policy

### DIFF
--- a/frontend/src/components/Forms/AddServer.vue
+++ b/frontend/src/components/Forms/AddServer.vue
@@ -91,20 +91,7 @@
                             :label="$t('label.password')"
                         >
                             <span slot="prepend">
-                                <v-tooltip bottom>
-                                    <template v-slot:activator="{ on, attrs }">
-                                        <v-icon
-                                            v-on="on"
-                                            v-bind="attrs"
-                                            @click="generatePassword"
-                                            class="mr-2"
-                                            tabindex="-1"
-                                        >
-                                            mdi-auto-fix
-                                        </v-icon>
-                                    </template>
-                                    <span v-html="$t('label.generate_password')" />
-                                </v-tooltip>
+                                <PasswordGenerator @password="insertPassword"/>
                             </span>
                             <span slot="append">
                                 <v-tooltip bottom>
@@ -187,9 +174,13 @@
 import { defineComponent } from '@vue/composition-api'
 import EventBus from "@/event"
 import http from "@/utils/http"
+import PasswordGenerator from "../PasswordGenerator";
 
 export default defineComponent({
     name: "AddServer",
+    components: {
+        PasswordGenerator
+    },
     data: () => ({
         open: false ,
         secret_id: null,
@@ -286,21 +277,9 @@ export default defineComponent({
             this.open = false
         },
 
-        generatePassword() {
-            this.loading = true
-
-            const params = {
-                folder_id: this.folder_id
-            }
-
-            http.get("/api/v1/secret/generate", { params: params })
-                .then((response) => {
-                    this.form.password.value = response.data
-                })
-                .then(() => {
-                    this.loading = false
-                })
-        },
+        insertPassword(newPassword){
+            this.form.password.value = newPassword;
+        }, 
 
         hasErrors(error) {
             const mapping = {

--- a/frontend/src/components/PasswordGenerator.vue
+++ b/frontend/src/components/PasswordGenerator.vue
@@ -1,0 +1,204 @@
+<template>
+    <v-menu
+      v-model="menu"
+      :close-on-content-click="false"
+      :nudge-width="300"
+      offset-x
+      left
+    >
+      <template v-slot:activator="{ on, attrs }">
+        <v-icon
+            v-on="on"
+            v-bind="attrs"
+            @click="getProperties"
+        >
+            mdi-auto-fix
+        </v-icon>
+      </template>
+
+      <v-card>
+        <v-list>
+          <v-list-item>
+            <v-list-item-icon>
+                <v-icon>mdi-lock</v-icon>
+            </v-list-item-icon>
+            <v-list-item-content>
+              <v-list-item-title>{{ $t("title.password_generator") }}</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+
+        <v-divider></v-divider>
+
+        <v-list>
+            <v-list-item>
+                <v-text-field
+                    :label="$t('label.password')"
+                    readonly
+                    :loading="passwordLoading"
+                    v-model="password"
+                >
+                    <template v-slot:append>
+                        <v-btn
+                            icon
+                            @click="generatePassword"
+                        >
+                            <v-icon>mdi-refresh</v-icon>
+                        </v-btn>
+                    </template>
+                </v-text-field>
+            </v-list-item>
+            <v-list-item dense>
+                <v-list-item-content>
+                    <v-list-item-title>{{ $t("label.min_length") }} : {{ length }}</v-list-item-title>
+                    <v-slider
+                        dense
+                        v-model="length"
+                        thumb-label
+                        :min="policy['length']"
+                        max="100"
+                        @end="generatePassword"
+                    >
+                    </v-slider>
+                </v-list-item-content>
+            </v-list-item>
+            <v-list-item dense>
+                <v-list-item-content>
+                    <v-list-item-title>{{ $t("label.min_uppercase") }} : {{ uppercase }}</v-list-item-title>
+                    <v-slider
+                        dense
+                        v-model="uppercase"
+                        thumb-label
+                        :min="policy.uppercase"
+                        :max="length"
+                        @end="generatePassword"
+                    >
+                    </v-slider>
+                </v-list-item-content>
+            </v-list-item>
+            <v-list-item dense>
+                <v-list-item-content>
+                    <v-list-item-title>{{ $t("label.min_numbers") }} : {{ numbers }}</v-list-item-title>
+                    <v-slider
+                        dense
+                        v-model="numbers"
+                        thumb-label
+                        :min="policy.numbers"
+                        :max="length"
+                        @end="generatePassword"
+                    >
+                    </v-slider>
+                </v-list-item-content>
+            </v-list-item>
+            <v-list-item dense>
+                <v-list-item-content>
+                    <v-list-item-title>{{ $t("label.min_special") }} : {{ special }}</v-list-item-title>
+                    <v-slider
+                        dense
+                        v-model="special"
+                        thumb-label
+                        :min="policy.special"
+                        :max="length"
+                        @end="generatePassword"
+                    >
+                    </v-slider>
+                </v-list-item-content>
+            </v-list-item>
+        </v-list>
+        
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+
+          <v-btn
+            text
+            @click="menu = false"
+          >
+            {{ $t("button.cancel")}}
+          </v-btn>
+          <v-btn
+            color="primary"
+            text
+            @click="sendPassword"
+          >
+            {{ $t("button.validate")}}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-menu>
+</template>
+<script>
+import { defineComponent } from '@vue/composition-api';
+import http from "@/utils/http";
+import { mapGetters } from 'vuex';
+
+export default defineComponent({
+    name: "PasswordGenerator",
+
+    data : () => ({
+        menu: false,
+        password: "",
+        passwordLoading: false,
+        length: 12,
+        uppercase: 1,
+        numbers: 1,
+        special: 1
+    }),
+
+    computed: {
+        ...mapGetters({
+          policy: 'getPasswordPolicy',
+          folder_id: "getFolder"
+        })
+    },
+
+    methods:{
+        getProperties(){
+            ["length","uppercase","numbers","special"].forEach(prop => {
+                this[prop] = this.policy[prop];
+            });
+            this.generatePassword();
+        },
+        generatePassword(){
+            this.passwordLoading = true;
+            this.fakePassword(3);
+            const data = {
+                length: this.length,
+                uppercase: this.uppercase,
+                numbers: this.numbers,
+                special: this.special,
+            };
+            const query = {
+                    folder_id: this.folder_id
+            };
+
+
+            http.post(`/api/v1/secret/generate`, data, {params: query}).then((res) => {
+                this.passwordLoading = false;
+                this.password = res.data;
+            })
+        },
+
+        sendPassword(){
+            this.$emit("password", this.password);
+            this.menu = false;
+        },
+
+        fakePassword(count=1){
+            let passwordKeys = "";
+            let password = "";
+            passwordKeys += "abcdefghijklmnopqrstuvwxyz";
+            if (this.uppercase) passwordKeys += "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+            if (this.numbers) passwordKeys += "1234567890";
+            if (this.special) passwordKeys += "&#?!%*$";
+
+            for (let i = 0; i < this.length; i++) {
+                const index = Math.floor(Math.random() * passwordKeys.length);
+                password += passwordKeys[index];
+            }
+            this.password = password;
+            if (--count > 0) setTimeout(this.fakePassword, 50, count);
+        }
+    }    
+})
+</script>

--- a/frontend/src/components/Treeview.vue
+++ b/frontend/src/components/Treeview.vue
@@ -144,6 +144,7 @@ export default defineComponent({
                     tree[0].isExpanded = true
                     tree[0].isSelected = true
                     this.$store.dispatch("set_current_folder", tree[0].data._id)
+                    this.$store.dispatch("set_current_password_policy", tree[0].data._id)
                     EventBus.$emit("selectedFolder", {
                         _id: tree[0].data._id,
                         name: tree[0].data.name,
@@ -152,6 +153,7 @@ export default defineComponent({
                 }
             } else {
                 this.$store.dispatch("set_current_folder", selected_folder)
+                this.$store.dispatch("set_current_password_policy", selected_folder)
                 EventBus.$emit("selectedFolder", {
                     _id: found._id,
                     name: found.name,
@@ -193,6 +195,7 @@ export default defineComponent({
             
             localStorage.setItem("selected_folder", folder_id)
             this.$store.dispatch("set_current_folder", folder_id)
+            this.$store.dispatch("set_current_password_policy", folder_id)
         },
 
         toggleFolder(selected) {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -181,7 +181,11 @@
         "admin_configuration": "Administrator",
         "twilio_phone_number": "Twilio Phone Number",
         "twilio_account_sid": "Twilio Account SID",
-        "twilio_auth_token": "Twilio Auth Token"
+        "twilio_auth_token": "Twilio Auth Token",
+        "min_special": "Minimum special character(s)",
+        "min_uppercase": "Minimum uppercase letter(s)",
+        "min_numbers": "Minimum number(s)",
+        "min_length": "Password minimum length"
     },
     "tooltip": {
         "dblclick_copy": "Double click to copy",
@@ -208,7 +212,8 @@
         "2fa_setup": "Two Factor Authentication Setup",
         "2fa_disable": "Disable Two Factor Authentication",
         "share_workspace": "Share workspace",
-        "add_user_to_workspace": "Share workspace to user(s)"
+        "add_user_to_workspace": "Share workspace to user(s)",
+        "password_generator": "Generate a password for your secret"
     },
     "required": {
         "required": "Required",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -178,7 +178,11 @@
         "admin_configuration": "Administrateur",
         "twilio_phone_number": "Numéro de téléphone Twilio",
         "twilio_account_sid": "Twilio Account SID",
-        "twilio_auth_token": "Twilio Auth Token"
+        "twilio_auth_token": "Twilio Auth Token",
+        "min_special": "Minimum de caractères spéciaux",
+        "min_uppercase": "Minimum de majuscules",
+        "min_numbers": "Minimum de chiffres",
+        "min_length": "Taille minimum du mot de passe"
     },
     "tooltip": {
         "dblclick_copy": "Double cliquez pour copier",
@@ -205,7 +209,8 @@
         "2fa_setup": "Authentification Multi Facteur",
         "2fa_disable": "Désactiver l'authentification multi facteur",
         "share_workspace": "Partager l'espace de travail",
-        "add_user_to_workspace": "Partage l'espace de travail à ces utilisateurs"
+        "add_user_to_workspace": "Partage l'espace de travail à ces utilisateurs",
+        "password_generator": "Générer un mot de passe pour votre secret"
     },
     "required": {
         "required": "Obligatoire",

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -13,6 +13,12 @@ export default new Vuex.Store({
         twilio: false,
         current_folder: null,
         selected_workspace: null,
+        current_password_policy: {
+            length: 12,
+            uppercase: 1,
+            numbers: 1,
+            special: 1,
+        },
     },
 
     getters: {
@@ -21,6 +27,7 @@ export default new Vuex.Store({
         getTwilio: state => state.twilio,
         getUser: state => state.user,
         getPro: state => state.pro,
+        getPasswordPolicy: state => state.current_password_policy,
     },
 
     mutations: {
@@ -39,6 +46,10 @@ export default new Vuex.Store({
         SET_CURRENT_FOLDER(state, folder) {
             state.current_folder = folder
             EventBus.$emit("refreshSecrets")
+        },
+
+        SET_CURRENT_PASSWORD_POLICY(state, policy) {
+            state.current_password_policy = policy
         },
 
         async REFRESH_USER(state) {
@@ -81,6 +92,27 @@ export default new Vuex.Store({
 
         set_current_folder({ commit }, folder_id) {
             commit("SET_CURRENT_FOLDER", folder_id)
+        },
+
+        async set_current_password_policy({ commit }, folder_id) {
+            let policy;
+            const response = await http.get(`/api/v1/folder/${folder_id}`);
+            const folder = response.data;
+            if (response.status !== 200) return;
+            policy = folder.password_policy;
+            if(!policy) {
+                const wk = (await http.get(`/api/v1/workspace/${folder.workspace}`)).data;
+                policy = wk.password_policy;
+                if(!policy) {
+                    policy = {
+                        length: 12,
+                        uppercase: 1,
+                        numbers: 1,
+                        special: 1,
+                    }
+                }
+            }
+            commit("SET_CURRENT_PASSWORD_POLICY", policy);
         },
 
         change_workspace({ commit }, workspace_id) {


### PR DESCRIPTION
The user is now able to generate more complex secrets than the folder's policy.

He can increase the **length** of the password but also the **minimum number of uppercase letters, digits and symbols**.
By default those values correspond to the f**older's policy** (you cannot generate a secret that doesn't match the current policy).

The /secret/generate endpoint has been modified in order to be able to handle a new optional parameter : the policy.
That new policy is compared to the current one (of the folder). If the new one is more complex than the current, your password is generated.

The password generator UI is a menu which can be shown by clicking on the magic stick (previous button to generate):
![image](https://user-images.githubusercontent.com/78411800/200631415-5e36b23f-adab-4c0e-b861-1ec7af0c783c.png)
A little animation is running when you generate a secret 
